### PR TITLE
Fixed compilation using Visual Studio 2015 (#34)

### DIFF
--- a/deps/tesseract/ccutil/platform.h
+++ b/deps/tesseract/ccutil/platform.h
@@ -28,7 +28,9 @@
 #define ultoa _ultoa
 #endif  /* __GNUC__ */
 #define SIGNED
+#if defined(_MSC_VER) && _MSC_VER < 1900
 #define snprintf _snprintf
+#endif
 #if (_MSC_VER <= 1400)
 #define vsnprintf _vsnprintf
 #endif /* _WIN32 */

--- a/deps/tesseract/textord/cjkpitch.cpp
+++ b/deps/tesseract/textord/cjkpitch.cpp
@@ -426,7 +426,7 @@ class FPRow {
         box2.height() >= pitch * (1.0 + kFPTolerance)) return false;
 
     const float real_pitch = box_pitch(box1, box2);
-    if (abs(real_pitch - pitch) < pitch * kFPTolerance) return true;
+    if (fabs(real_pitch - pitch) < pitch * kFPTolerance) return true;
 
     if (textord_space_size_is_variable) {
       // Hangul characters usually have fixed pitch, but words are
@@ -633,7 +633,7 @@ void FPRow::EstimatePitch(bool pass1) {
         // characters. and within tolerance in pass2.
         if (pass1 ||
             (prev_was_good &&
-             abs(estimated_pitch_ - pitch) < kFPTolerance * estimated_pitch_)) {
+             fabs(estimated_pitch_ - pitch) < kFPTolerance * estimated_pitch_)) {
           good_pitches_.Add(pitch);
           if (!is_box_modified(i - 1) && !is_box_modified(i)) {
             good_gaps_.Add(gap);

--- a/deps/tesseract/viewer/svutil.h
+++ b/deps/tesseract/viewer/svutil.h
@@ -27,7 +27,9 @@
 #ifdef _WIN32
 #ifndef __GNUC__
 #include <windows.h>
+#if defined(_MSC_VER) && _MSC_VER < 1900
 #define snprintf _snprintf
+#endif
 #if (_MSC_VER <= 1400)
 #define vsnprintf _vsnprintf
 #endif


### PR DESCRIPTION
This also fixes a bug on Windows where you cannot compile cjkpitch.cpp due to an ambiguous call to abs.