### PR TITLE
Fix for building on Windows

### DIFF
--- a/deps/common.gyp
+++ b/deps/common.gyp
@@ -18,6 +18,7 @@
       ],
       ['OS=="win"',
         {
+          'defines!': ['_HAS_EXCEPTIONS=0'],
           'configurations': {
             'Debug': {
               'msvs_settings': {


### PR DESCRIPTION
Undefined _HAS_EXCEPTIONS to address issues with msvc compilation on Windows.