### PR TITLE
Binarize adaptive

### DIFF
--- a/binding.gyp
+++ b/binding.gyp
@@ -10,6 +10,7 @@
         'deps/zxing/zxing.gyp:libzxing',
         'deps/opencv/opencv.gyp:libopencv',
         'deps/lswms/lswms.gyp:liblswms',
+        'deps/binarizeAdaptive/binarizeAdaptive.gyp:libBinarizeAdaptive',
       ],
       'include_dirs': [
         "<!(node -e \"require('nan')\")",
@@ -33,6 +34,7 @@
         'deps/opencv/modules/dynamicuda/include',
         'deps/opencv/modules/imgproc/include',
         'deps/lswms',
+        'deps/binarizeAdaptive/binarizeAdaptive'
        ],
       'sources': [
         'src/image.cc',

--- a/deps/binarizeAdaptive/binarizeAdaptive.cpp
+++ b/deps/binarizeAdaptive/binarizeAdaptive.cpp
@@ -1,0 +1,263 @@
+// *************************************************************
+// derived from http://liris.cnrs.fr/christian.wolf/software/binarize/index.html
+// Nick implementation informed by
+// https://github.com/MHassanNajafi/CUDA-Nick-Local-Image-Thresholding/blob/master/Nick_gold.cpp
+//
+// for more info comparing thes methods see the following paper
+// "Comparison of Niblack inspired binarization methods for ancient documents"
+// by Khurram Khurshid, Imran Siddiqi, Claudie Faure, Nicole Vincent
+// Proceedings of the SPIE, Volume 7247, id. 72470U (2009)
+// *************************************************************
+
+#include "binarizeAdaptive.h"
+#include <stdio.h>
+#include <unistd.h>
+#include "opencv2/imgproc/imgproc.hpp"
+
+using namespace cv;
+
+enum NiblackVersion
+{
+	NIBLACK=0,
+    SAUVOLA=1,
+    WOLFJOLION=2,
+    NICK=3
+};
+
+#define uget(x,y)    at<unsigned char>(y,x)
+#define uset(x,y,v)  at<unsigned char>(y,x)=v;
+#define fget(x,y)    at<float>(y,x)
+#define fset(x,y,v)  at<float>(y,x)=v;
+
+
+// *************************************************************
+// glide a window across the image and
+// create two maps: mean and standard deviation.
+//
+// Version patched by Thibault Yohan (using opencv integral images)
+// *************************************************************
+
+
+double calcLocalStats (Mat &im, Mat &map_m, Mat &map_s, int winx, int winy, bool isNick) {
+    Mat im_sum, im_sum_sq;
+
+    cv::integral(im, im_sum, im_sum_sq, CV_64F);
+
+	double m, s, max_s, sum, sum_sq;
+	int wxh	= winx/2;
+	int wyh	= winy/2;
+	int x_firstth = wxh;
+	int y_lastth = im.rows-wyh-1;
+	int y_firstth = wyh;
+	double winarea = winx*winy;
+
+	max_s = 0;
+	for	(int j = y_firstth ; j<=y_lastth; j++) {
+		sum = sum_sq = 0;
+
+        sum = im_sum.at<double>(j-wyh+winy,winx) - im_sum.at<double>(j-wyh,winx) - im_sum.at<double>(j-wyh+winy,0) + im_sum.at<double>(j-wyh,0);
+        sum_sq = im_sum_sq.at<double>(j-wyh+winy,winx) - im_sum_sq.at<double>(j-wyh,winx) - im_sum_sq.at<double>(j-wyh+winy,0) + im_sum_sq.at<double>(j-wyh,0);
+
+		m  = sum / winarea;
+		s  = sqrt((sum_sq - m * (isNick ? m : sum)) / winarea);
+		if (s > max_s) max_s = s;
+
+		map_m.fset(x_firstth, j, m);
+		map_s.fset(x_firstth, j, s);
+
+		// Shift the window, add and remove	new/old values to the histogram
+		for	(int i=1 ; i <= im.cols-winx; i++) {
+
+			// Remove the left old column and add the right new column
+			sum -= im_sum.at<double>(j-wyh+winy,i) - im_sum.at<double>(j-wyh,i) - im_sum.at<double>(j-wyh+winy,i-1) + im_sum.at<double>(j-wyh,i-1);
+			sum += im_sum.at<double>(j-wyh+winy,i+winx) - im_sum.at<double>(j-wyh,i+winx) - im_sum.at<double>(j-wyh+winy,i+winx-1) + im_sum.at<double>(j-wyh,i+winx-1);
+
+			sum_sq -= im_sum_sq.at<double>(j-wyh+winy,i) - im_sum_sq.at<double>(j-wyh,i) - im_sum_sq.at<double>(j-wyh+winy,i-1) + im_sum_sq.at<double>(j-wyh,i-1);
+			sum_sq += im_sum_sq.at<double>(j-wyh+winy,i+winx) - im_sum_sq.at<double>(j-wyh,i+winx) - im_sum_sq.at<double>(j-wyh+winy,i+winx-1) + im_sum_sq.at<double>(j-wyh,i+winx-1);
+
+			m  = sum / winarea;
+			s  = sqrt((sum_sq - m * (isNick ? m : sum)) / winarea);
+			if (s > max_s) max_s = s;
+
+			map_m.fset(i+wxh, j, m);
+			map_s.fset(i+wxh, j, s);
+		}
+	}
+
+	return max_s;
+}
+
+
+
+/**********************************************************
+ * The binarization routine
+ **********************************************************/
+void NiblackSauvolaWolfNick (Mat im, Mat output, NiblackVersion version,
+	int winx, int winy, double k, double dR) {
+
+	double m, s, max_s;
+	double th=0;
+	double min_I, max_I;
+	int wxh	= winx/2;
+	int wyh	= winy/2;
+	int x_firstth= wxh;
+	int x_lastth = im.cols-wxh-1;
+	int y_lastth = im.rows-wyh-1;
+	int y_firstth= wyh;
+	int mx, my;
+
+	// Create local statistics and store them in a double matrices
+	Mat map_m = Mat::zeros (im.rows, im.cols, CV_32F);
+	Mat map_s = Mat::zeros (im.rows, im.cols, CV_32F);
+
+	max_s = calcLocalStats(im, map_m, map_s, winx, winy, version == NICK);
+
+	minMaxLoc(im, &min_I, &max_I);
+
+	Mat thsurf (im.rows, im.cols, CV_32F);
+
+	// Create the threshold surface, including border processing
+	// ----------------------------------------------------
+
+	for	(int j = y_firstth ; j<=y_lastth; j++) {
+
+		// NORMAL, NON-BORDER AREA IN THE MIDDLE OF THE WINDOW:
+		for	(int i=0 ; i <= im.cols-winx; i++) {
+
+			m  = map_m.fget(i+wxh, j);
+    		s  = map_s.fget(i+wxh, j);
+
+    		// Calculate the threshold
+    		switch (version) {
+
+				case NICK: // s is calculated differently by calcLocalStats if version == NICK
+    			case NIBLACK:
+    				th = m + k * s;
+    				break;
+
+    			case SAUVOLA:
+	    			th = m * (1 + k * (s/dR-1));
+	    			break;
+
+    			case WOLFJOLION:
+    				th = m + k * (s/max_s-1) * (m-min_I);
+    				break;
+
+    			default:
+    				throw "Unknown threshold type in NiblackSauvolaWolfJolion()";
+    				exit (1);
+    		}
+
+    		thsurf.fset(i+wxh,j,th);
+
+    		if (i==0) {
+        		// LEFT BORDER
+        		for (int i=0; i<=x_firstth; ++i)
+                	thsurf.fset(i,j,th);
+
+        		// LEFT-UPPER CORNER
+        		if (j==y_firstth)
+        			for (int u=0; u<y_firstth; ++u)
+        			for (int i=0; i<=x_firstth; ++i)
+        				thsurf.fset(i,u,th);
+
+        		// LEFT-LOWER CORNER
+        		if (j==y_lastth)
+        			for (int u=y_lastth+1; u<im.rows; ++u)
+        			for (int i=0; i<=x_firstth; ++i)
+        				thsurf.fset(i,u,th);
+    		}
+
+			// UPPER BORDER
+			if (j==y_firstth)
+				for (int u=0; u<y_firstth; ++u)
+					thsurf.fset(i+wxh,u,th);
+
+			// LOWER BORDER
+			if (j==y_lastth)
+				for (int u=y_lastth+1; u<im.rows; ++u)
+					thsurf.fset(i+wxh,u,th);
+		}
+
+		// RIGHT BORDER
+		for (int i=x_lastth; i<im.cols; ++i)
+        	thsurf.fset(i,j,th);
+
+  		// RIGHT-UPPER CORNER
+		if (j==y_firstth)
+			for (int u=0; u<y_firstth; ++u)
+			for (int i=x_lastth; i<im.cols; ++i)
+				thsurf.fset(i,u,th);
+
+		// RIGHT-LOWER CORNER
+		if (j==y_lastth)
+			for (int u=y_lastth+1; u<im.rows; ++u)
+			for (int i=x_lastth; i<im.cols; ++i)
+				thsurf.fset(i,u,th);
+	}
+
+	for	(int y=0; y<im.rows; ++y)
+	for	(int x=0; x<im.cols; ++x)
+	{
+    	if (im.uget(x,y) >= thsurf.fget(x,y))
+    	{
+    		output.uset(x,y,255);
+    	}
+    	else
+    	{
+    	    output.uset(x,y,0);
+    	}
+    }
+}
+
+/**********************************************************
+ * The main function
+ **********************************************************/
+
+Mat binarize (Mat input, NiblackVersion versionCode, int winx, int winy, float optK)
+{
+
+    // Load the image in grayscale mode
+    if ((input.rows<=0) || (input.cols<=0)) {
+        throw "Couldn't read input image.";
+  		exit(1);
+    }
+
+    // Treat the window size
+    if (winx==0||winy==0) {
+        winy = (int) (2.0 * input.rows-1)/3;
+        winx = (int) input.cols-1 < winy ? input.cols-1 : winy;
+        // if the window is too big, than we assume that the image
+        // is not a single text box, but a document page: set
+        // the window size to a fixed constant.
+        if (winx > 100) {
+            winx = winy = 40;
+        }
+    }
+
+    // Threshold
+    Mat output (input.rows, input.cols, CV_8UC1);
+    NiblackSauvolaWolfNick(input, output, versionCode, winx, winy, optK, 128);
+
+    return output;
+}
+
+Mat binarizeNiblack (Mat input, int winx, int winy, float optK)
+{
+    return binarize(input, NIBLACK, winx, winy, optK);
+}
+
+Mat binarizeSauvola (Mat input, int winx, int winy, float optK)
+{
+    return binarize(input, SAUVOLA, winx, winy, optK);
+}
+
+Mat binarizeWolf (Mat input, int winx, int winy, float optK)
+{
+    return binarize(input, WOLFJOLION, winx, winy, optK);
+}
+
+Mat binarizeNick (Mat input, int winx, int winy, float optK)
+{
+    return binarize(input, NICK, winx, winy, optK);
+}

--- a/deps/binarizeAdaptive/binarizeAdaptive.gyp
+++ b/deps/binarizeAdaptive/binarizeAdaptive.gyp
@@ -1,0 +1,20 @@
+{
+  'includes': [ '../common.gyp' ],
+  'targets': [
+    {
+      'target_name': 'libBinarizeAdaptive',
+      'type': 'static_library',
+      'dependencies': [
+        '../opencv/opencv.gyp:libopencv'
+      ],
+      'include_dirs': [
+        '../opencv/include',
+        '../opencv/modules/core/include',
+        '../opencv/modules/imgproc/include',
+      ],
+      'sources': [
+        './binarizeAdaptive.cpp',
+      ],
+    },
+  ]
+}

--- a/deps/binarizeAdaptive/binarizeAdaptive.h
+++ b/deps/binarizeAdaptive/binarizeAdaptive.h
@@ -1,0 +1,11 @@
+#ifndef BINARIZEADAPTIVE
+#define BINARIZEADAPTIVE
+
+#include "opencv2/core/core.hpp"
+
+cv::Mat binarizeNiblack (cv::Mat input, int winx, int winy, float optK);
+cv::Mat binarizeSauvola (cv::Mat input, int winx, int winy, float optK);
+cv::Mat binarizeWolf (cv::Mat input, int winx, int winy, float optK);
+cv::Mat binarizeNick (cv::Mat input, int winx, int winy, float optK);
+
+#endif

--- a/src/image.cc
+++ b/src/image.cc
@@ -162,7 +162,7 @@ void pixProjection(std::vector<uint32_t> &values, PIX *pix, ProjectionMode mode)
     }
 }
 
-cv::Mat pix8ToMat(PIX *pix8)
+cv::Mat pix8ToMat(Pix *pix8)
 {
     cv::Mat mat(cv::Size(pix8->w, pix8->h), CV_8UC1);
     uint32_t *line = pix8->data;
@@ -173,6 +173,17 @@ cv::Mat pix8ToMat(PIX *pix8)
         line += pix8->wpl;
     }
     return mat;
+}
+
+Pix *mat8ToPix(cv::Mat *mat8)
+{
+	Pix *pixd = pixCreate(mat8->size().width, mat8->size().height, 8);
+	for(int i=0; i<mat8->rows; i++) {
+		for(int j=0; j<mat8->cols; j++) {
+			pixSetPixel(pixd, j, i, (l_uint32) mat8->at<uchar>(i,j));
+		}
+	}
+	return pixd;
 }
 
 bool Image::HasInstance(Handle<Value> val)

--- a/src/image.cc
+++ b/src/image.cc
@@ -7,16 +7,17 @@
  * MIT License <https://github.com/creatale/node-dv/blob/master/LICENSE>
  */
 #include "image.h"
-#include "util.h"
 #include <sstream>
 #include <algorithm>
 #include <cmath>
-#include <node_buffer.h>
-#include <lodepng.h>
-#include <jpgd.h>
-#include <jpge.h>
-#include <opencv2/core/core.hpp>
-#include <LSWMS.h>
+#include "util.h"
+#include "node_buffer.h"
+#include "lodepng.h"
+#include "jpgd.h"
+#include "jpge.h"
+#include "opencv2/core/core.hpp"
+#include "LSWMS.h"
+#include "binarizeAdaptive.h"
 
 #ifdef _MSC_VER
 #if _MSC_VER <= 1700
@@ -229,6 +230,8 @@ NAN_MODULE_INIT(Image::Init)
     Nan::SetPrototypeMethod(ctor, "thin", Thin);
     Nan::SetPrototypeMethod(ctor, "maxDynamicRange", MaxDynamicRange);
     Nan::SetPrototypeMethod(ctor, "otsuAdaptiveThreshold", OtsuAdaptiveThreshold);
+    Nan::SetPrototypeMethod(ctor, "wolfAdaptiveThreshold", WolfAdaptiveThreshold);
+    Nan::SetPrototypeMethod(ctor, "nickAdaptiveThreshold", NickAdaptiveThreshold);
     Nan::SetPrototypeMethod(ctor, "lineSegments", LineSegments);
     Nan::SetPrototypeMethod(ctor, "findSkew", FindSkew);
     Nan::SetPrototypeMethod(ctor, "connectedComponents", ConnectedComponents);
@@ -1007,6 +1010,48 @@ NAN_METHOD(Image::OtsuAdaptiveThreshold)
     } else {
         return Nan::ThrowTypeError("expected (sx: Int32, sy: Int32, "
                      "smoothx: Int32, smoothy: Int32, scoreFact: Number)");
+    }
+}
+
+NAN_METHOD(Image::WolfAdaptiveThreshold)
+{
+    Image *obj = Nan::ObjectWrap::Unwrap<Image>(info.Holder());
+
+    if (info[0]->IsInt32() && info[1]->IsInt32() && info[2]->IsNumber()) {
+		if (obj->pix_->d != 8) {
+			return Nan::ThrowTypeError("Not a 8bpp Image");
+		}
+        int32_t winx = info[0]->Int32Value();
+        int32_t winy = info[1]->Int32Value();
+        float optK = static_cast<float>(info[2]->NumberValue());
+        cv::Mat converted = binarizeWolf(pix8ToMat(obj->pix_), winx, winy, optK);
+        Pix *pixd = mat8ToPix(&converted);
+
+		info.GetReturnValue().Set(Image::New(pixConvertTo1(pixd, 128)));
+		return;
+    } else {
+        return Nan::ThrowTypeError("expected (winx: Int32, winy: Int32, optK: Number)");
+    }
+}
+
+NAN_METHOD(Image::NickAdaptiveThreshold)
+{
+    Image *obj = Nan::ObjectWrap::Unwrap<Image>(info.Holder());
+
+    if (info[0]->IsInt32() && info[1]->IsInt32() && info[2]->IsNumber()) {
+		if (obj->pix_->d != 8) {
+			return Nan::ThrowTypeError("Not a 8bpp Image");
+		}
+        int32_t winx = info[0]->Int32Value();
+        int32_t winy = info[1]->Int32Value();
+        float optK = static_cast<float>(info[2]->NumberValue());
+        cv::Mat converted = binarizeNick(pix8ToMat(obj->pix_), winx, winy, optK);
+        Pix *pixd = mat8ToPix(&converted);
+
+		info.GetReturnValue().Set(Image::New(pixConvertTo1(pixd, 128)));
+		return;
+    } else {
+        return Nan::ThrowTypeError("expected (winx: Int32, winy: Int32, optK: Number)");
     }
 }
 

--- a/src/image.h
+++ b/src/image.h
@@ -67,6 +67,8 @@ private:
     static NAN_METHOD(Thin);
     static NAN_METHOD(MaxDynamicRange);
     static NAN_METHOD(OtsuAdaptiveThreshold);
+    static NAN_METHOD(WolfAdaptiveThreshold);
+    static NAN_METHOD(NickAdaptiveThreshold);
     static NAN_METHOD(LineSegments);
     static NAN_METHOD(FindSkew);
     static NAN_METHOD(ConnectedComponents);

--- a/test/image.test.js
+++ b/test/image.test.js
@@ -175,6 +175,14 @@ describe('Image', function(){
         skew.angle.should.equal(-0.703125);
         skew.confidence.should.equal(4.957831859588623);
     })
+    it('should #wolfAdaptiveThreshold()', function(){
+        var threshold = this.gray.wolfAdaptiveThreshold(16, 16, 0.5);
+        writeImage('gray-threshold-wolf-image.png', threshold);
+    })
+    it('should #nickAdaptiveThreshold()', function(){
+        var threshold = this.gray.wolfAdaptiveThreshold(16, 16, -0.2);
+        writeImage('gray-threshold-nick-image.png', threshold);
+    })
     it('should #lineSegments(), #drawLine()', function(){
         var segments = this.gray.lineSegments(3, 0, false);
         var canvas = this.gray.toColor();


### PR DESCRIPTION
Adds Wolf and Nick binarization algorithms. both are locally adaptive algorithms and for many documents are a great improvement over the global optimization approach of Otsu. 

This implementation is derived from [the source Christian Wolf provided](http://liris.cnrs.fr/christian.wolf/software/binarize/) along with his original publication. His implementation is very efficient as it made use of integral images to speed up the moving window calculations that are the core of the Niblack algorithm both of these algorithms are based on. Subsequently I added the Nick algorithm to his code. I also added a handy mat8ToPix to complement the existing pix8ToMat in image.cc.

For a good comparison of these binarization techniques I point you to the excellent [Nick paper](https://ai2-s2-pdfs.s3.amazonaws.com/76bd/5997bdd6d0a2611c590f5cf30f95c88e18ad.pdf).

In short these algorithms performs admirably in situations such as locally shaded areas, bleed-through or stains where Otsu's global threshold would fail. The arguments are window width, height and a K parameter usually 0.5 for Wolf and between -0.1 and -0.2 for Nick.

Nick will often catch faint and thin features that Wolf will miss. Wolf can be less noisy. Both are often lighter and thinner than Otsu but then again also much more usable in many cases.

<img width="801" alt="compare" src="https://cloud.githubusercontent.com/assets/232036/18606757/635bc052-7c7e-11e6-84df-0527e14cd772.png">

